### PR TITLE
fix(docker): add latest tag on default branch

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -41,6 +41,7 @@ jobs:
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
I neglected to add the `latest` Docker tag to the image in the last PR. This will add the `latest` tag to the Docker images when built from the default GitHub branch.

Additionally, you might consider enabling "Packages" in your repo settings. 